### PR TITLE
Moving fast_align path to the config file

### DIFF
--- a/configs/test
+++ b/configs/test
@@ -19,8 +19,7 @@ clean_stem_dev=/export/b03/hxu/data-selection/clean_corpus/de-en/news.de-en
 #==============================================================================
 
 aligner=fast-align
-fast_align_bin=/home/pkoehn/statmt/project/fast_align/build/fast_align
-atools_bin=/home/pkoehn/statmt/project/fast_align/build/atools
+fast_align_build=/home/pkoehn/statmt/project/fast_align/build
 align_job=1
 
 dict_count_thresh=1

--- a/configs/test
+++ b/configs/test
@@ -19,6 +19,8 @@ clean_stem_dev=/export/b03/hxu/data-selection/clean_corpus/de-en/news.de-en
 #==============================================================================
 
 aligner=fast-align
+fast_align_bin=/home/pkoehn/statmt/project/fast_align/build/fast_align
+atools_bin=/home/pkoehn/statmt/project/fast_align/build/atools
 align_job=1
 
 dict_count_thresh=1

--- a/scripts/align-corpus.sh
+++ b/scripts/align-corpus.sh
@@ -16,9 +16,9 @@ if [ "$aligner" == "fast-align" ]; then
 
   if [ "$align_job" == "" ] || [ "$align_job" == "1" ]; then
     echo align with 1 job
-    $fast_align_bin -i $tmpfolder/pasted -d -o -v > $alignoutput.forward
-    $fast_align_bin -i $tmpfolder/pasted -d -o -v -r > $alignoutput.backward
-    $atools_bin -i $alignoutput.forward -j $alignoutput.backward -c grow-diag-final-and > $alignoutput
+    $fast_align_build/fast_align -i $tmpfolder/pasted -d -o -v > $alignoutput.forward
+    $fast_align_build/fast_align -i $tmpfolder/pasted -d -o -v -r > $alignoutput.backward
+    $fast_align_build/atools -i $alignoutput.forward -j $alignoutput.backward -c grow-diag-final-and > $alignoutput
   else
 #    shuf $tmpfolder/pasted > $tmpfolder/pasted.shuffed
     echo align with $align_job job

--- a/scripts/align-corpus.sh
+++ b/scripts/align-corpus.sh
@@ -16,9 +16,9 @@ if [ "$aligner" == "fast-align" ]; then
 
   if [ "$align_job" == "" ] || [ "$align_job" == "1" ]; then
     echo align with 1 job
-    /home/pkoehn/statmt/project/fast_align/build/fast_align -i $tmpfolder/pasted -d -o -v > $alignoutput.forward
-    /home/pkoehn/statmt/project/fast_align/build/fast_align -i $tmpfolder/pasted -d -o -v -r > $alignoutput.backward
-    /home/pkoehn/statmt/project/fast_align/build/atools -i $alignoutput.forward -j $alignoutput.backward -c grow-diag-final-and > $alignoutput
+    $fast_align_bin -i $tmpfolder/pasted -d -o -v > $alignoutput.forward
+    $fast_align_bin -i $tmpfolder/pasted -d -o -v -r > $alignoutput.backward
+    $atools_bin -i $alignoutput.forward -j $alignoutput.backward -c grow-diag-final-and > $alignoutput
   else
 #    shuf $tmpfolder/pasted > $tmpfolder/pasted.shuffed
     echo align with $align_job job


### PR DESCRIPTION
Avoids having the path to fast_align hardcoded in the aligner script, and allows to define it in the config file.